### PR TITLE
Add Raspberry Pi Python port

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ If you are experiencing problems with the firmware, please see the [Reporting Cr
 
 ## Pinout
 [![Pinout diagram](https://i.imgur.com/mjqNXxb.png)](https://github.com/nebkat/esp32-xbee/wiki/Pinout)
+
+## Raspberry Pi Python Port
+A minimal Python implementation is available in the `python` directory for running the bridge on a Raspberry Pi 4.
+See [python/README.md](python/README.md) for usage.
+

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,24 @@
+# Raspberry Pi Python Port
+
+This directory provides a minimal Python implementation of the ESP32-XBee firmware features.
+The script `rasp_xbee.py` acts as a simple NTRIP client bridge between a serial
+port and an NTRIP caster. It was designed for running on a Raspberry Pi 4.
+
+## Requirements
+* Python 3.7+
+* `pyserial`
+
+Install the dependency:
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+```bash
+python rasp_xbee.py --host <caster> --mountpoint <mount> \
+    --username <user> --password <pass> [--device /dev/serial0]
+```
+
+The script reads NMEA sentences from the specified serial device, extracts the
+latest GGA message and periodically forwards it to the NTRIP caster. Correction
+messages from the caster are written back to the serial port.

--- a/python/rasp_xbee.py
+++ b/python/rasp_xbee.py
@@ -1,0 +1,72 @@
+import argparse
+import base64
+import select
+import socket
+import sys
+import time
+
+try:
+    import serial
+except ImportError:
+    print("pyserial is required. Install with 'pip install pyserial'", file=sys.stderr)
+    sys.exit(1)
+
+
+def connect_ntrip(host, port, mountpoint, user=None, password=None):
+    sock = socket.create_connection((host, port))
+    headers = [f"GET /{mountpoint} HTTP/1.1",
+               "User-Agent: rasp-xbee-py",]
+    if user and password:
+        token = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers.append(f"Authorization: Basic {token}")
+    headers.append("\r\n")
+    request = "\r\n".join(headers)
+    sock.sendall(request.encode())
+    resp = sock.recv(1024)
+    if b"200" not in resp:
+        raise RuntimeError(f"Bad response from caster: {resp.splitlines()[0].decode(errors='ignore')}")
+    return sock
+
+
+def bridge(args):
+    ser = serial.Serial(args.device, args.baudrate, timeout=0)
+    sock = connect_ntrip(args.host, args.port, args.mountpoint, args.username, args.password)
+    latest_gga = b""
+    last_gga_sent = 0.0
+    while True:
+        r, _, _ = select.select([ser, sock], [], [], 1.0)
+        if ser in r:
+            data = ser.read(1024)
+            if data:
+                if data.startswith(b"$GPGGA") or data.startswith(b"$GNGGA"):
+                    latest_gga = data.strip() + b"\r\n"
+                # forward all serial data to socket? Not required except GGA
+        if sock in r:
+            data = sock.recv(1024)
+            if not data:
+                raise RuntimeError("Caster disconnected")
+            ser.write(data)
+        if latest_gga and time.time() - last_gga_sent > 15:
+            sock.sendall(latest_gga)
+            last_gga_sent = time.time()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple NTRIP client bridge for Raspberry Pi")
+    parser.add_argument('--device', default='/dev/serial0', help='Serial device path')
+    parser.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
+    parser.add_argument('--host', required=True, help='NTRIP caster hostname')
+    parser.add_argument('--port', type=int, default=2101, help='NTRIP caster port')
+    parser.add_argument('--mountpoint', required=True, help='Mountpoint to connect to')
+    parser.add_argument('--username', help='NTRIP username')
+    parser.add_argument('--password', help='NTRIP password')
+    args = parser.parse_args()
+
+    try:
+        bridge(args)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,1 @@
+pyserial


### PR DESCRIPTION
## Summary
- provide a simple Python NTRIP bridge in `python/rasp_xbee.py`
- document the Raspberry Pi port and usage instructions

## Testing
- `python3 -m py_compile python/rasp_xbee.py`
- `python3 python/rasp_xbee.py -h`

------
https://chatgpt.com/codex/tasks/task_e_687d5426d3d483239ea9fdeeb18bb991