### PR TITLE
Add optional config file support

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -4,6 +4,10 @@ This directory provides a minimal Python implementation of the ESP32-XBee firmwa
 The script `rasp_xbee.py` acts as a simple NTRIP client bridge between a serial
 port and an NTRIP caster. It was designed for running on a Raspberry Pi 4.
 
+By default the script looks for a configuration file at `/etc/rasp_xbee.conf`.
+Values from this file provide defaults for command line arguments, but any
+values supplied on the CLI take precedence.
+
 ## Requirements
 * Python 3.7+
 * `pyserial`
@@ -22,3 +26,22 @@ python rasp_xbee.py --host <caster> --mountpoint <mount> \
 The script reads NMEA sentences from the specified serial device, extracts the
 latest GGA message and periodically forwards it to the NTRIP caster. Correction
 messages from the caster are written back to the serial port.
+
+## Configuration file
+
+`rasp_xbee.py` will attempt to read `/etc/rasp_xbee.conf` on start up. The file
+uses INI syntax and values from the `DEFAULT` section are applied as argument
+defaults. Command line flags override any options from the file.
+
+Example:
+
+```ini
+[DEFAULT]
+device = /dev/ttyUSB0
+baudrate = 460800
+host = ntrip.example.com
+port = 2101
+mountpoint = MY-RTCM3
+username = user
+password = pass
+```

--- a/python/config.py
+++ b/python/config.py
@@ -1,0 +1,19 @@
+import configparser
+from pathlib import Path
+
+CONFIG_PATH = '/etc/rasp_xbee.conf'
+
+
+def load_config(path: str = CONFIG_PATH) -> dict:
+    """Load configuration from *path* if it exists.
+
+    Returns a dictionary of options. Unknown files result in an
+    empty dictionary.
+    """
+    parser = configparser.ConfigParser()
+    file = Path(path)
+    if file.is_file():
+        parser.read(path)
+        # Use DEFAULT section for simplicity
+        return dict(parser.defaults())
+    return {}

--- a/python/rasp_xbee.py
+++ b/python/rasp_xbee.py
@@ -5,6 +5,8 @@ import socket
 import sys
 import time
 
+from config import load_config
+
 try:
     import serial
 except ImportError:
@@ -52,14 +54,22 @@ def bridge(args):
 
 
 def main():
+    defaults = load_config()
+
+    def get_int(key, fallback):
+        try:
+            return int(defaults.get(key, fallback))
+        except (TypeError, ValueError):
+            return fallback
+
     parser = argparse.ArgumentParser(description="Simple NTRIP client bridge for Raspberry Pi")
-    parser.add_argument('--device', default='/dev/serial0', help='Serial device path')
-    parser.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
-    parser.add_argument('--host', required=True, help='NTRIP caster hostname')
-    parser.add_argument('--port', type=int, default=2101, help='NTRIP caster port')
-    parser.add_argument('--mountpoint', required=True, help='Mountpoint to connect to')
-    parser.add_argument('--username', help='NTRIP username')
-    parser.add_argument('--password', help='NTRIP password')
+    parser.add_argument('--device', default=defaults.get('device', '/dev/serial0'), help='Serial device path')
+    parser.add_argument('--baudrate', type=int, default=get_int('baudrate', 115200), help='Serial baudrate')
+    parser.add_argument('--host', default=defaults.get('host'), required='host' not in defaults, help='NTRIP caster hostname')
+    parser.add_argument('--port', type=int, default=get_int('port', 2101), help='NTRIP caster port')
+    parser.add_argument('--mountpoint', default=defaults.get('mountpoint'), required='mountpoint' not in defaults, help='Mountpoint to connect to')
+    parser.add_argument('--username', default=defaults.get('username'), help='NTRIP username')
+    parser.add_argument('--password', default=defaults.get('password'), help='NTRIP password')
     args = parser.parse_args()
 
     try:


### PR DESCRIPTION
## Summary
- add `python/config.py` helper using `configparser`
- allow `rasp_xbee.py` to load defaults from `/etc/rasp_xbee.conf`
- document config file usage and precedence in `python/README.md`

## Testing
- `python -m py_compile python/*.py`
- `pip install -r python/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_687d68b477a8832384972c974722eeb2