### PR TITLE
Add Python NTRIP server and caster

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,8 +1,7 @@
 # Raspberry Pi Python Port
 
 This directory provides a minimal Python implementation of the ESP32-XBee firmware features.
-The script `rasp_xbee.py` acts as a simple NTRIP client bridge between a serial
-port and an NTRIP caster. It was designed for running on a Raspberry Pi 4.
+The script `rasp_xbee.py` can operate as an NTRIP client, server or caster and was designed for running on a Raspberry Pi 4.
 
 ## Requirements
 * Python 3.7+
@@ -14,11 +13,23 @@ pip install -r requirements.txt
 ```
 
 ## Usage
-```bash
-python rasp_xbee.py --host <caster> --mountpoint <mount> \
-    --username <user> --password <pass> [--device /dev/serial0]
-```
 
-The script reads NMEA sentences from the specified serial device, extracts the
-latest GGA message and periodically forwards it to the NTRIP caster. Correction
-messages from the caster are written back to the serial port.
+### Client
+```bash
+python rasp_xbee.py --mode client --host <caster> --mountpoint <mount> \
+    --username <user> --password <pass>
+```
+Connects to an external caster and forwards corrections to the serial port.
+
+### Server
+```bash
+python rasp_xbee.py --mode server --port 2101
+```
+Waits for a base station connection and writes received data to the serial device.
+
+### Caster
+```bash
+python rasp_xbee.py --mode caster --port 2101 --mountpoint MOUNT \
+    [--username user --password pass]
+```
+Allows multiple NTRIP clients to connect to the caster. Corrections from the serial device are forwarded to all clients.

--- a/python/ntrip_caster.py
+++ b/python/ntrip_caster.py
@@ -1,0 +1,147 @@
+import argparse
+import base64
+import select
+import socket
+import sys
+
+try:
+    import serial
+except ImportError:  # pragma: no cover - environment check only
+    print("pyserial is required. Install with 'pip install pyserial'", file=sys.stderr)
+    sys.exit(1)
+
+
+class Client:
+    def __init__(self, conn):
+        self.conn = conn
+        self.conn.setblocking(False)
+
+
+def _parse_headers(data):
+    lines = data.split('\r\n')
+    headers = {}
+    for line in lines[1:]:
+        if ':' in line:
+            k, v = line.split(':', 1)
+            headers[k.strip().lower()] = v.strip()
+    return lines[0], headers
+
+
+def _send_sourcetable(conn, mountpoint, username, user_agent):
+    stream = f"STR;{mountpoint};;;;;;;;0.00;0.00;0;0;;none;{'N' if not username else 'B'};N;0;\r\nENDSOURCETABLE"
+    body = stream.encode()
+    header = (
+        f"SOURCETABLE 200 OK\r\n"
+        f"Server: NTRIP Caster/1.0\r\n"
+        f"Content-Type: text/plain\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        f"Connection: close\r\n\r\n"
+    )
+    if 'ntrip' not in user_agent.lower():
+        header = header.replace('SOURCETABLE 200 OK', 'HTTP/1.0 200 OK')
+    conn.sendall(header.encode() + body)
+
+
+def _send_unauthorized(conn, mountpoint):
+    message = b"Authorization Required"
+    header = (
+        f"HTTP/1.0 401 Unauthorized\r\n"
+        f"Server: NTRIP Caster/1.0\r\n"
+        f"WWW-Authenticate: Basic realm=\"/{mountpoint}\"\r\n"
+        f"Content-Type: text/plain\r\n"
+        f"Content-Length: {len(message)}\r\n"
+        f"Connection: close\r\n\r\n"
+    )
+    conn.sendall(header.encode() + message)
+
+
+def _handle_handshake(conn, mountpoint, username, password):
+    data = conn.recv(1024).decode(errors='ignore')
+    if not data:
+        conn.close()
+        return None
+    first, headers = _parse_headers(data)
+    if not first.startswith('GET'):
+        conn.sendall(b"HTTP/1.1 405 Method Not Allowed\r\nAllow: GET\r\n\r\n")
+        conn.close()
+        return None
+    path = first.split()[1]
+    if path.startswith('/'):
+        path = path[1:]
+    user_agent = headers.get('user-agent', '')
+    if path != mountpoint:
+        _send_sourcetable(conn, mountpoint, username, user_agent)
+        conn.close()
+        return None
+    if username:
+        auth = headers.get('authorization', '')
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        if auth != f"Basic {token}":
+            _send_unauthorized(conn, mountpoint)
+            conn.close()
+            return None
+    conn.sendall(b"ICY 200 OK\r\n\r\n")
+    return Client(conn)
+
+
+def run_caster(args):
+    """Run a very small NTRIP caster."""
+    ser = serial.Serial(args.device, args.baudrate, timeout=0)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((args.bind, args.port))
+    sock.listen(5)
+
+    clients = []
+    try:
+        while True:
+            rlist = [sock, ser] + [c.conn for c in clients]
+            r, _, _ = select.select(rlist, [], [], 1.0)
+            if sock in r:
+                conn, _ = sock.accept()
+                c = _handle_handshake(conn, args.mountpoint, args.username, args.password)
+                if c:
+                    clients.append(c)
+            if ser in r:
+                data = ser.read(1024)
+                if data:
+                    dead = []
+                    for c in clients:
+                        try:
+                            c.conn.sendall(data)
+                        except OSError:
+                            dead.append(c)
+                    for d in dead:
+                        d.conn.close()
+                        clients.remove(d)
+            for c in clients:
+                if c.conn in r:
+                    if not c.conn.recv(1024):
+                        c.conn.close()
+                        clients.remove(c)
+    finally:
+        for c in clients:
+            c.conn.close()
+        sock.close()
+        ser.close()
+
+
+def add_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument('--bind', default='0.0.0.0', help='Address to bind')
+    parser.add_argument('--port', type=int, default=2101, help='TCP listen port')
+    parser.add_argument('--mountpoint', default='MOUNT', help='Caster mountpoint')
+    parser.add_argument('--username', default='', help='Require username')
+    parser.add_argument('--password', default='', help='Require password')
+
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser(description='Simple NTRIP caster')
+    ap.add_argument('--device', default='/dev/serial0', help='Serial device path')
+    ap.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
+    add_arguments(ap)
+    args = ap.parse_args()
+    try:
+        run_caster(args)
+    except KeyboardInterrupt:
+        pass

--- a/python/ntrip_server.py
+++ b/python/ntrip_server.py
@@ -1,0 +1,66 @@
+import argparse
+import select
+import socket
+import sys
+
+try:
+    import serial
+except ImportError:  # pragma: no cover - environment check only
+    print("pyserial is required. Install with 'pip install pyserial'", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_server(args):
+    """Accept RTCM from a base station and forward to a serial port."""
+    ser = serial.Serial(args.device, args.baudrate, timeout=0)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((args.bind, args.port))
+    sock.listen(1)
+
+    conn = None
+    try:
+        while True:
+            rlist = [sock, ser]
+            if conn:
+                rlist.append(conn)
+            r, _, _ = select.select(rlist, [], [], 1.0)
+            if sock in r:
+                if conn:
+                    conn.close()
+                conn, addr = sock.accept()
+                conn.setblocking(False)
+                print(f"Base connected from {addr}")
+            if conn and conn in r:
+                data = conn.recv(1024)
+                if not data:
+                    conn.close()
+                    conn = None
+                else:
+                    ser.write(data)
+            if ser in r:
+                # Discard any data coming from serial
+                ser.read(1024)
+    finally:
+        if conn:
+            conn.close()
+        sock.close()
+        ser.close()
+
+
+def add_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument('--bind', default='0.0.0.0', help='Address to bind')
+    parser.add_argument('--port', type=int, default=2101, help='TCP listen port')
+
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser(description='Simple NTRIP server')
+    ap.add_argument('--device', default='/dev/serial0', help='Serial device path')
+    ap.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
+    add_arguments(ap)
+    args = ap.parse_args()
+    try:
+        run_server(args)
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
## Summary
- add `ntrip_server.py` module for receiving base corrections over TCP
- add `ntrip_caster.py` module that supports multiple clients with auth
- extend `rasp_xbee.py` with modes to run as client, server or caster
- update README with usage examples

## Testing
- `python -m py_compile python/rasp_xbee.py python/ntrip_server.py python/ntrip_caster.py`

------
https://chatgpt.com/codex/tasks/task_e_687d68b72bb883239b6b9a1d6124ade7