### PR TITLE
Add Python socket server/client bridge

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -14,11 +14,32 @@ pip install -r requirements.txt
 ```
 
 ## Usage
+`rasp_xbee.py` now provides several sub-commands. Common serial options are
+`--device` and `--baudrate`.
+
+### NTRIP client
 ```bash
-python rasp_xbee.py --host <caster> --mountpoint <mount> \
-    --username <user> --password <pass> [--device /dev/serial0]
+python rasp_xbee.py ntrip --host <caster> --mountpoint <mount> \
+    --username <user> --password <pass>
 ```
 
-The script reads NMEA sentences from the specified serial device, extracts the
-latest GGA message and periodically forwards it to the NTRIP caster. Correction
-messages from the caster are written back to the serial port.
+The script reads NMEA sentences from the serial device, extracts the latest GGA
+message and periodically forwards it to the NTRIP caster. Corrections from the
+caster are written back to the serial port.
+
+## Socket Server
+`socket_server.py` (or `rasp_xbee.py server`) exposes the serial port over TCP
+and UDP similarly to the firmware's socket server.
+
+```bash
+python socket_server.py [--tcp-port 23] [--udp-port 2323] [--device /dev/serial0]
+```
+
+## Socket Client
+`socket_client.py` (or `rasp_xbee.py client`) connects the serial port to a
+remote TCP or UDP host.
+
+```bash
+python socket_client.py --host <host> --port <port> [--udp] \
+    [--connect-message "hello"] [--device /dev/serial0]
+```

--- a/python/socket_client.py
+++ b/python/socket_client.py
@@ -1,0 +1,75 @@
+import argparse
+import select
+import socket
+import sys
+import time
+
+try:
+    import serial
+except ImportError:
+    print("pyserial is required. Install with 'pip install pyserial'", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_client(ser, host, port, udp=False, connect_message=None):
+    while True:
+        try:
+            if udp:
+                sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+                sock.connect((host, port))
+            else:
+                sock = socket.create_connection((host, port))
+            if connect_message:
+                sock.sendall(connect_message.encode())
+        except OSError as e:
+            print(f"Failed to connect to {host}:{port}: {e}")
+            time.sleep(5)
+            continue
+
+        while True:
+            r, _, _ = select.select([ser, sock], [], [], 1.0)
+            if ser in r:
+                data = ser.read(ser.in_waiting or 1024)
+                if data:
+                    try:
+                        if udp:
+                            sock.send(data)
+                        else:
+                            sock.sendall(data)
+                    except OSError:
+                        break
+            if sock in r:
+                try:
+                    data = sock.recv(1024)
+                    if not data:
+                        break
+                    ser.write(data)
+                except OSError:
+                    break
+        try:
+            sock.close()
+        except Exception:
+            pass
+        print(f"Disconnected from {host}:{port}, retrying...")
+        time.sleep(5)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Serial socket client bridge")
+    parser.add_argument('--device', default='/dev/serial0', help='Serial device path')
+    parser.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
+    parser.add_argument('--host', required=True, help='Server hostname')
+    parser.add_argument('--port', type=int, required=True, help='Server port')
+    parser.add_argument('--udp', action='store_true', help='Use UDP instead of TCP')
+    parser.add_argument('--connect-message', help='Message to send after connecting')
+    args = parser.parse_args()
+
+    ser = serial.Serial(args.device, args.baudrate, timeout=0)
+    try:
+        run_client(ser, args.host, args.port, args.udp, args.connect_message)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/python/socket_server.py
+++ b/python/socket_server.py
@@ -1,0 +1,81 @@
+import argparse
+import select
+import socket
+import sys
+
+try:
+    import serial
+except ImportError:
+    print("pyserial is required. Install with 'pip install pyserial'", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_server(ser, tcp_port, udp_port):
+    server_tcp = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    server_tcp.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_tcp.bind(("", tcp_port))
+    server_tcp.listen(1)
+
+    server_udp = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+    server_udp.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_udp.bind(("", udp_port))
+
+    tcp_clients = []
+    udp_clients = set()
+
+    while True:
+        sockets = [server_tcp, server_udp] + tcp_clients + [ser]
+        r, _, _ = select.select(sockets, [], [], 1.0)
+
+        if ser in r:
+            data = ser.read(ser.in_waiting or 1024)
+            if data:
+                for c in tcp_clients[:]:
+                    try:
+                        c.sendall(data)
+                    except OSError:
+                        tcp_clients.remove(c)
+                        c.close()
+                for addr in list(udp_clients):
+                    try:
+                        server_udp.sendto(data, addr)
+                    except OSError:
+                        udp_clients.discard(addr)
+
+        if server_tcp in r:
+            client, addr = server_tcp.accept()
+            tcp_clients.append(client)
+
+        if server_udp in r:
+            data, addr = server_udp.recvfrom(1024)
+            udp_clients.add(addr)
+            if data:
+                ser.write(data)
+
+        for c in tcp_clients[:]:
+            if c in r:
+                data = c.recv(1024)
+                if not data:
+                    tcp_clients.remove(c)
+                    c.close()
+                else:
+                    ser.write(data)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Serial TCP/UDP socket server bridge")
+    parser.add_argument('--device', default='/dev/serial0', help='Serial device path')
+    parser.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
+    parser.add_argument('--tcp-port', type=int, default=23, help='TCP listen port')
+    parser.add_argument('--udp-port', type=int, default=2323, help='UDP listen port')
+    args = parser.parse_args()
+
+    ser = serial.Serial(args.device, args.baudrate, timeout=0)
+    try:
+        run_server(ser, args.tcp_port, args.udp_port)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add socket server and client modules mirroring C implementation
- extend rasp_xbee.py with sub-commands to run NTRIP, server, or client bridges
- update Python README with usage examples

## Testing
- `python -m py_compile python/rasp_xbee.py python/socket_server.py python/socket_client.py`

------
https://chatgpt.com/codex/tasks/task_e_687d68b91edc83238b487342d129ce07