### PR TITLE
Add Python service file

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -22,3 +22,15 @@ python rasp_xbee.py --host <caster> --mountpoint <mount> \
 The script reads NMEA sentences from the specified serial device, extracts the
 latest GGA message and periodically forwards it to the NTRIP caster. Correction
 messages from the caster are written back to the serial port.
+
+## Service Installation
+To run the bridge automatically at boot, copy `rasp_xbee.service` to `/etc/systemd/system`:
+```bash
+sudo cp rasp_xbee.service /etc/systemd/system/
+```
+Enable and start the service:
+```bash
+sudo systemctl enable rasp_xbee
+sudo systemctl start rasp_xbee
+```
+Edit the service file to configure the `ExecStart` parameters for your environment.

--- a/python/rasp_xbee.service
+++ b/python/rasp_xbee.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Raspberry Pi NTRIP bridge
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/rasp-xbee/python
+ExecStart=/usr/bin/python3 rasp_xbee.py --host <caster> --mountpoint <mount> --username <user> --password <pass>
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add `rasp_xbee.service` for running the Python bridge via systemd
- document installing and enabling the service

## Testing
- `python3 -m py_compile python/rasp_xbee.py`

------
https://chatgpt.com/codex/tasks/task_e_687d68c013cc8323b36ef950b54fc160