### PR TITLE
Add pytest tests and parser helper

### DIFF
--- a/python/rasp_xbee.py
+++ b/python/rasp_xbee.py
@@ -12,6 +12,20 @@ except ImportError:
     sys.exit(1)
 
 
+def create_parser():
+    parser = argparse.ArgumentParser(
+        description="Simple NTRIP client bridge for Raspberry Pi"
+    )
+    parser.add_argument('--device', default='/dev/serial0', help='Serial device path')
+    parser.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
+    parser.add_argument('--host', required=True, help='NTRIP caster hostname')
+    parser.add_argument('--port', type=int, default=2101, help='NTRIP caster port')
+    parser.add_argument('--mountpoint', required=True, help='Mountpoint to connect to')
+    parser.add_argument('--username', help='NTRIP username')
+    parser.add_argument('--password', help='NTRIP password')
+    return parser
+
+
 def connect_ntrip(host, port, mountpoint, user=None, password=None):
     sock = socket.create_connection((host, port))
     headers = [f"GET /{mountpoint} HTTP/1.1",
@@ -51,16 +65,9 @@ def bridge(args):
             last_gga_sent = time.time()
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Simple NTRIP client bridge for Raspberry Pi")
-    parser.add_argument('--device', default='/dev/serial0', help='Serial device path')
-    parser.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
-    parser.add_argument('--host', required=True, help='NTRIP caster hostname')
-    parser.add_argument('--port', type=int, default=2101, help='NTRIP caster port')
-    parser.add_argument('--mountpoint', required=True, help='Mountpoint to connect to')
-    parser.add_argument('--username', help='NTRIP username')
-    parser.add_argument('--password', help='NTRIP password')
-    args = parser.parse_args()
+def main(argv=None):
+    parser = create_parser()
+    args = parser.parse_args(argv)
 
     try:
         bridge(args)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,2 @@
 pyserial
+pytest

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import rasp_xbee
+
+
+def test_load_config_defaults():
+    parser = rasp_xbee.create_parser()
+    args = parser.parse_args(['--host', 'example.com', '--mountpoint', 'MOUNT'])
+    assert args.device == '/dev/serial0'
+    assert args.baudrate == 115200
+    assert args.port == 2101
+    assert args.host == 'example.com'
+    assert args.mountpoint == 'MOUNT'
+    assert args.username is None
+    assert args.password is None
+
+
+def test_load_config_custom():
+    parser = rasp_xbee.create_parser()
+    args = parser.parse_args([
+        '--device', '/dev/ttyUSB0',
+        '--baudrate', '9600',
+        '--host', 'host',
+        '--port', '1234',
+        '--mountpoint', 'POINT',
+        '--username', 'u',
+        '--password', 'p'
+    ])
+    assert args.device == '/dev/ttyUSB0'
+    assert args.baudrate == 9600
+    assert args.port == 1234
+    assert args.username == 'u'
+    assert args.password == 'p'

--- a/tests/test_ntrip.py
+++ b/tests/test_ntrip.py
@@ -1,0 +1,58 @@
+import os
+import socket
+import sys
+import threading
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import rasp_xbee
+
+
+def _make_socketpair():
+    return socket.socketpair()
+
+
+def test_connect_ntrip_success(monkeypatch):
+    client, server = _make_socketpair()
+
+    def fake_create_connection(addr):
+        return client
+
+    def server_thread():
+        request = server.recv(1024)
+        assert b"GET /MOUNT HTTP/1.1" in request
+        server.sendall(b"HTTP/1.1 200 OK\r\n\r\n")
+
+    th = threading.Thread(target=server_thread)
+    th.start()
+
+    monkeypatch.setattr(socket, 'create_connection', fake_create_connection)
+    sock = rasp_xbee.connect_ntrip('localhost', 2101, 'MOUNT')
+    th.join(timeout=1)
+    server.close()
+    sock.close()
+
+
+def test_connect_ntrip_failure(monkeypatch):
+    client, server = _make_socketpair()
+
+    def fake_create_connection(addr):
+        return client
+
+    def server_thread():
+        server.recv(1024)
+        server.sendall(b"HTTP/1.1 401 Unauthorized\r\n\r\n")
+
+    th = threading.Thread(target=server_thread)
+    th.start()
+
+    monkeypatch.setattr(socket, 'create_connection', fake_create_connection)
+    try:
+        rasp_xbee.connect_ntrip('localhost', 2101, 'MOUNT')
+    except RuntimeError as e:
+        assert "Bad response" in str(e)
+    else:
+        raise AssertionError("Expected RuntimeError")
+    th.join(timeout=1)
+    server.close()
+    client.close()


### PR DESCRIPTION
## Summary
- expose an argument parser creator in `rasp_xbee.py`
- make `main` accept argv for testing
- add pytest-based tests for config parsing and NTRIP responses
- add pytest to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d68c2e5e483239e4d49c637ddb0b8